### PR TITLE
Fix server crash by try-catch around mongoose connection stablish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
+ARGUMENTS=$(filter-out $@,$(MAKECMDGOALS))
+
 install:
 	docker-compose run node npm install
 
 run-tests:
-	MONGO_PATH=mongodb://mongo:27017 docker-compose run node npm run test
+	docker-compose run node npm run test
+
+npm:
+	docker-compose run node npm $(ARGUMENTS)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     environment:
       NODE_OPTIONS: --experimental-vm-modules # needed for jest to work with ESM
       MONGO_DB_NAME: ${MONGO_DB_NAME-discordia}
-      MONGO_PATH: ${MONGO_PATH-'mongodb://mongo:27017'}
+      MONGO_PATH: mongodb://mongo:27017
     depends_on:
       - mongo
 

--- a/src/database/adapter/Mongo.js
+++ b/src/database/adapter/Mongo.js
@@ -1,12 +1,17 @@
 import mongoose from 'mongoose';
 
 export default async () => {
-    await mongoose.connect(process.env.MONGO_PATH, {
-        useNewUrlParser: true,
-        useUnifiedTopology: true,
-        dbName: process.env.MONGO_DB_NAME,
-        user: process.env.MONGO_USER,
-        pass: process.env.MONGO_PASSWORD,
-    });
+    try {
+        await mongoose.connect(process.env.MONGO_PATH, {
+            useNewUrlParser: true,
+            useUnifiedTopology: true,
+            dbName: process.env.MONGO_DB_NAME,
+            user: process.env.MONGO_USER,
+            pass: process.env.MONGO_PASSWORD,
+        });
+    } catch (error) {
+        console.log('1621847075 MongoDB connection error:');
+        console.error(error);
+    }
     return mongoose;
 };


### PR DESCRIPTION
Summary:
The server used to crash 'randomly' without useful error-logging.
This was because mongoose could not establish a database connection
via the provided url in `process.env.MONGO_PATH`. By fixing the url
when running in node docker container it is no fixed when run via
docker-compose.
The try-catch now also loggs a detailed error message.